### PR TITLE
Implement group member list in Go

### DIFF
--- a/example/testdata.go
+++ b/example/testdata.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	. "github.com/protosam/go-libnss"
+	. "github.com/protosam/go-libnss/structs"
 )
 
 // Test database objects.
@@ -9,74 +9,74 @@ var dbtest_passwd []Passwd
 var dbtest_group []Group
 var dbtest_shadow []Shadow
 
-func init(){
+func init() {
 	// Populates the passwd test db.
 	dbtest_passwd = append(dbtest_passwd,
 		Passwd{
-			Username:		"testguy1",
-			Password:		"x",
-			UID:			1500,
-			GID:			1500,
-			Gecos:			"Test user 1",
-			Dir:			"/home/testguy1",
-			Shell:			"/bin/bash",
+			Username: "testguy1",
+			Password: "x",
+			UID:      1500,
+			GID:      1500,
+			Gecos:    "Test user 1",
+			Dir:      "/home/testguy1",
+			Shell:    "/bin/bash",
 		},
 		Passwd{
-			Username:		"testguy2",
-			Password:		"x",
-			UID:			1501,
-			GID:			1501,
-			Gecos:			"Test user 2",
-			Dir:			"/home/testguy2",
-			Shell:			"/bin/bash",
+			Username: "testguy2",
+			Password: "x",
+			UID:      1501,
+			GID:      1501,
+			Gecos:    "Test user 2",
+			Dir:      "/home/testguy2",
+			Shell:    "/bin/bash",
 		},
 	)
 
 	// Populates the group test db.
 	dbtest_group = append(dbtest_group,
 		Group{
-			Groupname:			"testguy1",
-			Password:			"x",
-			GID:				1500,
-			Members:			[]string{ "testguy1" },
+			Groupname: "testguy1",
+			Password:  "x",
+			GID:       1500,
+			Members:   []string{"testguy1"},
 		},
 		Group{
-			Groupname:			"testguy2",
-			Password:			"x",
-			GID:				1501,
-			Members:			[]string{ "testguy2" },
+			Groupname: "testguy2",
+			Password:  "x",
+			GID:       1501,
+			Members:   []string{"testguy2"},
 		},
 		Group{
-			Groupname:			"testguyz",
-			Password:			"x",
-			GID:				1499,
-			Members:			[]string{ "testguy1", "testguy2" },
+			Groupname: "testguyz",
+			Password:  "x",
+			GID:       1499,
+			Members:   []string{"testguy1", "testguy2"},
 		},
 	)
 
 	// Populates the shadow test db.
 	dbtest_shadow = append(dbtest_shadow,
 		Shadow{
-			Username:			"testguy1",
-			Password:			"$6$yZcX.DOY$7bgsJhILMYl3DfMZsYUwoObbVt5Sj9FuujuhVn05Vg9hk.2AXLNy6o1DcPNq0SIyaRZ5YBZer2rYaycuh3qtg1", // Password is "password"
-			LastChange:			17920,
-			MinChange:			0,
-			MaxChange:			99999,
-			PasswordWarn:		7,
-			InactiveLockout:	-1,
-			ExpirationDate:		-1,
-			Reserved:			-1,
+			Username:        "testguy1",
+			Password:        "$6$yZcX.DOY$7bgsJhILMYl3DfMZsYUwoObbVt5Sj9FuujuhVn05Vg9hk.2AXLNy6o1DcPNq0SIyaRZ5YBZer2rYaycuh3qtg1", // Password is "password"
+			LastChange:      17920,
+			MinChange:       0,
+			MaxChange:       99999,
+			PasswordWarn:    7,
+			InactiveLockout: -1,
+			ExpirationDate:  -1,
+			Reserved:        -1,
 		},
 		Shadow{
-			Username:			"testguy2",
-			Password:			"$6$yZcX.DOY$7bgsJhILMYl3DfMZsYUwoObbVt5Sj9FuujuhVn05Vg9hk.2AXLNy6o1DcPNq0SIyaRZ5YBZer2rYaycuh3qtg1", // Password is "password"
-			LastChange:			17920,
-			MinChange:			0,
-			MaxChange:			99999,
-			PasswordWarn:		7,
-			InactiveLockout:	0,
-			ExpirationDate:		0,
-			Reserved:			-1,
+			Username:        "testguy2",
+			Password:        "$6$yZcX.DOY$7bgsJhILMYl3DfMZsYUwoObbVt5Sj9FuujuhVn05Vg9hk.2AXLNy6o1DcPNq0SIyaRZ5YBZer2rYaycuh3qtg1", // Password is "password"
+			LastChange:      17920,
+			MinChange:       0,
+			MaxChange:       99999,
+			PasswordWarn:    7,
+			InactiveLockout: 0,
+			ExpirationDate:  0,
+			Reserved:        -1,
 		},
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/protosam/go-libnss
+
+go 1.14


### PR DESCRIPTION
This PR uses Go and the NSS buffer to store the group's members, instead of relying on the previous C code, and extra allocations.

@protosam: I'm using this technique in another implementation. I'm also using Go to define the NSS methods instead of C like you, it makes the code more simple, but you cannot use macros to set the module name.

I've seen that you have an implementation using etcd, mine also uses HTTP request to talk with an external service, but I been having some problems with the last version of Ubuntu 20.04, but not with older ones. Somehow when using NSS for SSH access one specific HTTP request hangs always in the same place in the second SSHD child, but not in the first one. I also tried to implement a part of those HTTP requests using your interface and it has the exact same problem. I am wondering if you have experienced something like that.